### PR TITLE
Use External ZOFU if present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,8 +118,12 @@ export(EXPORT fson-targets
 option(FSON_ENABLE_TESTS "Build and enable unit tests" ON)
 
 if (FSON_ENABLE_TESTS)
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
     find_package(ZOFU QUIET)
-    if (NOT ZOFU_FOUND AND NOT ZOFU_DRIVER)
+    if (NOT ZOFU_FOUND OR
+            NOT ZOFU_DRIVER OR
+            NOT ZOFU_LIBRARY OR
+            NOT ZOFU_MODULE_PATH)
         message("Fetching and building external ZOFU")
         include(FetchContent OPTIONAL RESULT_VARIABLE fc_LOADED)
         if (${fc_LOADED} MATCHES NOTFOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,9 @@ export(EXPORT fson-targets
 option(FSON_ENABLE_TESTS "Build and enable unit tests" ON)
 
 if (FSON_ENABLE_TESTS)
+    # Use the distributed copy of FindZOFU.cmake if we don't find a
+    # system wide version.  Note this should be updated if this becomes
+    # default available.
     list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
     find_package(ZOFU QUIET)
     if (NOT ZOFU_FOUND OR
@@ -137,8 +140,6 @@ if (FSON_ENABLE_TESTS)
             FetchContent_Populate(zofu)
         endif()
 
-        # Building zofu could be replaced with the proper target if it had a
-        # CMake build.
         add_library(zofu SHARED
             ${zofu_SOURCE_DIR}/src/zofu.F90
             ${zofu_SOURCE_DIR}/src/zofu_kinds.F90

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,28 +118,35 @@ export(EXPORT fson-targets
 option(FSON_ENABLE_TESTS "Build and enable unit tests" ON)
 
 if (FSON_ENABLE_TESTS)
-    include(FetchContent OPTIONAL RESULT_VARIABLE fc_LOADED)
-    if (${fc_LOADED} MATCHES NOTFOUND)
-        include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/FetchContent.cmake)
-    endif()
-    FetchContent_Declare(zofu
-        GIT_REPOSITORY https://github.com/acroucher/zofu.git
-    )
-    FetchContent_GetProperties(zofu)
-    if (NOT zofu_POPULATED)
-        FetchContent_Populate(zofu)
-    endif()
+    find_package(ZOFU QUIET)
+    if (NOT ZOFU_FOUND AND NOT ZOFU_DRIVER)
+        message("Fetching and building external ZOFU")
+        include(FetchContent OPTIONAL RESULT_VARIABLE fc_LOADED)
+        if (${fc_LOADED} MATCHES NOTFOUND)
+            include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/FetchContent.cmake)
+        endif()
+        FetchContent_Declare(zofu
+            GIT_REPOSITORY https://github.com/acroucher/zofu.git
+        )
+        FetchContent_GetProperties(zofu)
+        if (NOT zofu_POPULATED)
+            FetchContent_Populate(zofu)
+        endif()
 
-    # Building zofu could be replaced with the proper target if it had a
-    # CMake build.
-    add_library(zofu SHARED
-        ${zofu_SOURCE_DIR}/src/zofu.F90
-        ${zofu_SOURCE_DIR}/src/zofu_kinds.F90
-        ${zofu_SOURCE_DIR}/src/zofu_scan.F90
-        ${zofu_SOURCE_DIR}/src/zofu_str_utils.F90
-    )
-    add_executable(zofu-driver ${zofu_SOURCE_DIR}/src/zofu_driver.F90)
-    target_link_libraries(zofu-driver zofu)
+        # Building zofu could be replaced with the proper target if it had a
+        # CMake build.
+        add_library(zofu SHARED
+            ${zofu_SOURCE_DIR}/src/zofu.F90
+            ${zofu_SOURCE_DIR}/src/zofu_kinds.F90
+            ${zofu_SOURCE_DIR}/src/zofu_scan.F90
+            ${zofu_SOURCE_DIR}/src/zofu_str_utils.F90
+        )
+        add_executable(zofu-driver ${zofu_SOURCE_DIR}/src/zofu_driver.F90)
+        target_link_libraries(zofu-driver zofu)
+
+        set(ZOFU_LIBRARY zofu)
+        set(ZOFU_DRIVER ${CMAKE_CURRENT_BINARY_DIR}/zofu-driver)
+    endif()
 
     # Defining each test is a matter of generating the source, building the
     # executable, and adding the test.
@@ -148,20 +155,20 @@ if (FSON_ENABLE_TESTS)
         add_library(${test_name}_lib
             src/tests/${test_name}_zofu.f90
         )
-        target_link_libraries(${test_name}_lib FSON::FSON zofu)
+    target_link_libraries(${test_name}_lib FSON::FSON ${ZOFU_LIBRARY})
 
         add_custom_command(OUTPUT
             ${CMAKE_CURRENT_BINARY_DIR}/${test_name}_driver.f90
-            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/zofu-driver
+            COMMAND ${ZOFU_DRIVER}
                 ${CMAKE_CURRENT_SOURCE_DIR}/src/tests/${test_name}_zofu.f90
                 ${CMAKE_CURRENT_BINARY_DIR}/${test_name}_driver.f90
-                DEPENDS zofu-driver
+                DEPENDS ${ZOFU_DRIVER}
             )
 
         add_executable(${test_name}
             ${CMAKE_CURRENT_SOURCE_DIR}/src/tests/${test_name}_zofu.f90
             ${CMAKE_CURRENT_BINARY_DIR}/${test_name}_driver.f90)
-        target_link_libraries(${test_name} FSON::FSON zofu)
+        target_link_libraries(${test_name} FSON::FSON ${ZOFU_LIBRARY})
         add_test(NAME ${test_name} COMMAND ${test_name}
                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/tests)
     endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ if (FSON_ENABLE_TESTS)
 
         set(ZOFU_LIBRARY zofu)
         set(ZOFU_DRIVER ${CMAKE_CURRENT_BINARY_DIR}/zofu-driver)
+        set(ZOFU_MODULE_PATH ${CMAKE_CURRENT_BINARY_DIR})
     endif()
 
     # Defining each test is a matter of generating the source, building the
@@ -155,7 +156,8 @@ if (FSON_ENABLE_TESTS)
         add_library(${test_name}_lib
             src/tests/${test_name}_zofu.f90
         )
-    target_link_libraries(${test_name}_lib FSON::FSON ${ZOFU_LIBRARY})
+        target_link_libraries(${test_name}_lib FSON::FSON ${ZOFU_LIBRARY})
+        target_include_directories(${test_name}_lib PUBLIC ${ZOFU_MODULE_PATH})
 
         add_custom_command(OUTPUT
             ${CMAKE_CURRENT_BINARY_DIR}/${test_name}_driver.f90
@@ -169,6 +171,7 @@ if (FSON_ENABLE_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/src/tests/${test_name}_zofu.f90
             ${CMAKE_CURRENT_BINARY_DIR}/${test_name}_driver.f90)
         target_link_libraries(${test_name} FSON::FSON ${ZOFU_LIBRARY})
+        target_include_directories(${test_name} PUBLIC ${ZOFU_MODULE_PATH})
         add_test(NAME ${test_name} COMMAND ${test_name}
                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/tests)
     endforeach()

--- a/cmake/FindZOFU.cmake
+++ b/cmake/FindZOFU.cmake
@@ -1,0 +1,100 @@
+# Summary:
+# Implementation of find_package() for zofu Fortran unit testing
+# library from https://github.com/acroucher/zofu
+#
+# Input:
+# These variables are unconfirmed, set by the user
+# ZOFU_BINARY_PATH - path containing zofu-driver. Windows also contains libzofu.dll
+# ZOFU_LIBRARY_PATH - path containing libzofu.so, libzofu.dll.a
+# ZOFU_MODULE_PATH - path containing zofu.mod, zofu_kinds.mod, zofu_scan.mod, zofu_str_utils.mod
+#
+# Output:
+# These variables are confirmed or set by CMake
+# ZOFU_FOUND - boolean; status indicating output variables are set
+# ZOFU_DRIVER - full path to zofu-driver
+# ZOFU_LIBRARY_NAME - common name of library ("zofu"; as passed to -l)
+# ZOFU_LIBRARY - full path to libzofu.so (or .a or .dll.a)
+# ZOFU_LIBRARY_DIR - confirmed library path (should equal ZOFU_LIBRARY_PATH) as passed to -L
+# ZOFU_MODULE_DIR - confirmed Fortran module path (should equal ZOFU_MODULE_PATH) as passed to -I
+
+### Initial conditions ###
+
+set(ZOFU_FOUND OFF)
+
+set(ZOFU_LIBRARY_NAME zofu)
+
+set(ZOFU_BINARY_PATH  "" CACHE PATH "zofu binary directory path")
+set(ZOFU_LIBRARY_PATH "" CACHE PATH "zofu library directory path")
+set(ZOFU_MODULE_PATH  "" CACHE PATH "zofu Fortran module directory path")
+
+### Search for artifacts ###
+
+# Find zofu-driver in bindir
+find_program(ZOFU_DRIVER zofu-driver
+    PATHS "${ZOFU_BINARY_PATH}" ~/.local/bin
+)
+
+# Find zofu library in libdir (let CMake guess at actual file name
+# based on common library name)
+find_library(ZOFU_LIBRARY ${ZOFU_LIBRARY_NAME}
+    PATHS "${ZOFU_LIBRARY_PATH}" ~/.local/lib
+)
+
+if(ZOFU_LIBRARY)
+    get_filename_component(ZOFU_LIBRARY_DIR "${ZOFU_LIBRARY}" DIRECTORY)
+    set(ZOFU_FOUND ON)
+# else()
+#     # ZOFU_FOUND is already OFF - just PASS
+endif()
+
+# Find zofu module directory based on single check for zofu.mod
+find_file(ZOFU_MODULE ${ZOFU_LIBRARY_NAME}.mod
+    PATHS "${ZOFU_MODULE_PATH}" ~/.local/finclude/zofu ~/Documents/Projects/git-proj/zofu/build/libzofu.so.p
+)
+
+if(ZOFU_MODULE)
+    get_filename_component(ZOFU_MODULE_DIR "${ZOFU_MODULE}" DIRECTORY)
+    # If ZOFU_FOUND is ON, leave it ON - just PASS
+else()
+    # If ZOFU_FOUND is ON, turn it OFF
+    set(ZOFU_FOUND OFF)
+endif()
+
+### Display results ###
+
+# Diagnostics
+if(ZOFU_FOUND)
+    message(STATUS "Zofu Fortran testing library is available")
+    # message(STATUS "ZOFU_DRIVER set to ${ZOFU_DRIVER}")
+    # message(STATUS "ZOFU_LIBRARY_NAME set to ${ZOFU_LIBRARY_NAME}")
+    # message(STATUS "ZOFU_LIBRARY set to ${ZOFU_LIBRARY}")
+    # message(STATUS "ZOFU_LIBRARY_DIR set to ${ZOFU_LIBRARY_DIR}")
+    # message(STATUS "ZOFU_MODULE (${ZOFU_LIBRARY_NAME}.mod) set to ${ZOFU_MODULE}")
+    # message(STATUS "ZOFU_MODULE_DIR set to ${ZOFU_MODULE_DIR}")
+else()
+    message(STATUS "Zofu Fortran testing library is not available")
+    # message(STATUS "ZOFU_DRIVER set to ${ZOFU_DRIVER}")
+    # message(STATUS "ZOFU_LIBRARY_NAME set to ${ZOFU_LIBRARY_NAME}")
+    # message(STATUS "ZOFU_LIBRARY set to ${ZOFU_LIBRARY}")
+    # message(STATUS "ZOFU_LIBRARY_DIR set to ${ZOFU_LIBRARY_DIR}")
+    # message(STATUS "ZOFU_MODULE (${ZOFU_LIBRARY_NAME}.mod) set to ${ZOFU_MODULE}")
+    # message(STATUS "ZOFU_MODULE_DIR set to ${ZOFU_MODULE_DIR}")
+endif()
+
+# if(ZOFU_BINARY_PATH)
+#     message(STATUS "Input ZOFU_BINARY_PATH specified as ${ZOFU_BINARY_PATH}")
+# else()
+#     message(STATUS "Input ZOFU_BINARY_PATH not specified")
+# endif()
+
+# if(ZOFU_LIBRARY_PATH)
+#     message(STATUS "Input ZOFU_LIBRARY_PATH specified as ${ZOFU_LIBRARY_PATH}")
+# else()
+#     message(STATUS "Input ZOFU_LIBRARY_PATH not specified")
+# endif()
+
+# if(ZOFU_MODULE_PATH)
+#     message(STATUS "Input ZOFU_MODULE_PATH specified as ${ZOFU_MODULE_PATH}")
+# else()
+#     message(STATUS "Input ZOFU_MODULE_PATH not specified")
+# endif()


### PR DESCRIPTION
A user may have a copy of ZOFU installed in a known location. This change set allows the user to specify ZOFU's installation details according to its [`find_package` script](https://github.com/acroucher/zofu/blob/master/contrib/cmake/FindZOFU.cmake) and it will respect that.  A copy of the find_package script is included for general usability since ZOFU does not install its `find_pacakge` script by default. This will fall back to fetching and building ZOFU if the user specified library is not available.

Closes #31 